### PR TITLE
Update go version in 3-install-free5gc.md

### DIFF
--- a/docs/guide/3-install-free5gc.md
+++ b/docs/guide/3-install-free5gc.md
@@ -15,27 +15,27 @@
 You will not be able to run most of the tests in [Test](https://github.com/free5gc/free5gc/wiki/Test) section unless you deploy a UPF.
 
 2. Golang Version
-    * As noted above, free5gc is built and tested with Go 1.17.8
+    * As noted above, free5gc is built and tested with Go 1.18
     * To check the version of Go on your system, from a command prompt:
 
     ```bash
         go version
     ```
 
-    * If another version of Go is installed, remove the existing version and install Go 1.17.8:
+    * If another version of Go is installed, remove the existing version and install Go 1.18:
 
     ```bash
         # this assumes your current version of Go is in the default location
         sudo rm -rf /usr/local/go
-        wget https://dl.google.com/go/go1.17.8.linux-amd64.tar.gz
-        sudo tar -C /usr/local -zxvf go1.17.8.linux-amd64.tar.gz
+        wget https://dl.google.com/go/go1.18.linux-amd64.tar.gz
+        sudo tar -C /usr/local -zxvf go1.18.linux-amd64.tar.gz
     ```
 
     * If Go is not installed on your system:
 
     ```bash
-        wget https://dl.google.com/go/go1.17.8.linux-amd64.tar.gz
-        sudo tar -C /usr/local -zxvf go1.17.8.linux-amd64.tar.gz
+        wget https://dl.google.com/go/go1.18.linux-amd64.tar.gz
+        sudo tar -C /usr/local -zxvf go1.18.linux-amd64.tar.gz
         mkdir -p ~/go/{bin,pkg,src}
         # The following assume that your shell is bash
         echo 'export GOPATH=$HOME/go' >> ~/.bashrc

--- a/docs/guide/3-install-free5gc.md
+++ b/docs/guide/3-install-free5gc.md
@@ -15,27 +15,27 @@
 You will not be able to run most of the tests in [Test](https://github.com/free5gc/free5gc/wiki/Test) section unless you deploy a UPF.
 
 2. Golang Version
-    * As noted above, free5gc is built and tested with Go 1.18
+    * As noted above, free5gc is built and tested with Go 1.18.10
     * To check the version of Go on your system, from a command prompt:
 
     ```bash
         go version
     ```
 
-    * If another version of Go is installed, remove the existing version and install Go 1.18:
+    * If another version of Go is installed, remove the existing version and install Go 1.18.10:
 
     ```bash
         # this assumes your current version of Go is in the default location
         sudo rm -rf /usr/local/go
-        wget https://dl.google.com/go/go1.18.linux-amd64.tar.gz
-        sudo tar -C /usr/local -zxvf go1.18.linux-amd64.tar.gz
+        wget https://dl.google.com/go/go1.18.10.linux-amd64.tar.gz
+        sudo tar -C /usr/local -zxvf go1.18.10.linux-amd64.tar.gz
     ```
 
     * If Go is not installed on your system:
 
     ```bash
-        wget https://dl.google.com/go/go1.18.linux-amd64.tar.gz
-        sudo tar -C /usr/local -zxvf go1.18.linux-amd64.tar.gz
+        wget https://dl.google.com/go/go1.18.10.linux-amd64.tar.gz
+        sudo tar -C /usr/local -zxvf go1.18.10.linux-amd64.tar.gz
         mkdir -p ~/go/{bin,pkg,src}
         # The following assume that your shell is bash
         echo 'export GOPATH=$HOME/go' >> ~/.bashrc


### PR DESCRIPTION
In free5gc-compose, building with 1.17.8 fails with errors like [#12 15.50 /go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/binding/form.go:22:48: undefined: any] which is fixed in 1.18

Full error logs: https://github.com/free5gc/free5gc-compose/actions/runs/6147575308/job/17345854254
Fixed by: https://github.com/free5gc/free5gc-compose/commit/7f7cec7987f2268a6cd2bc7c755bad8c67da81a7