### PR TITLE
Blog: Fix free5gc OAuth2 Procedure

### DIFF
--- a/docs/blog/20231115/free5GC_OAuth2_Procedure.md
+++ b/docs/blog/20231115/free5GC_OAuth2_Procedure.md
@@ -10,9 +10,10 @@
 
 ![OAuth2_Light](./OAuth2_light.png)
 
-[0]. NF_Registration: See TS 29.510 Section5.2.2.2 NFRegister for more details.
-[1]. The GetTokenCtx() function generates a context and inserts the access token into the request header.
-[2]. If the token has expired, the NF would use SendAccTokenReq() to obtain a new token from NRF.
+**Description** 
+[0]. NF_Registration: See *TS 29.510 Section5.2.2.2 NFRegister* for more details.
+[1]. The ```GetTokenCtx()``` function generates a context and inserts the access token into the request header.
+[2]. If the token has expired, the NF would use ```SendAccTokenReq()``` to obtain a new token from NRF.
 [3]. NRF would verify the request NFType and the requested service for authorization, and issue the token if authorized.
 
 ## Note

--- a/docs/blog/20231115/free5GC_OAuth2_Procedure.md
+++ b/docs/blog/20231115/free5GC_OAuth2_Procedure.md
@@ -5,9 +5,6 @@
 > Date: 2023/11/15
 ---
 
-
-![OAuth2_Dark](./OAuth2_dark.png)
-
 ![OAuth2_Light](./OAuth2_light.png)
 
 **Description** 
@@ -18,6 +15,9 @@
 
 ## Note
 The OAuth2 functions are under development in free5GC. They will be released after thorough testing. Furthermore, there may be a more detailed workflow article related to this topic.
+
+Additionally, I have provided the graph with a dark background.
+![OAuth2_Dark](./OAuth2_dark.png)
 
 ## About
 Hello, I am Andy Chen. I have just started making contributions to the free5GC core network. This post is my first blog, so if there are any inquiries or identification of errors within, we welcome discussion and correction. Your feedback is invaluable, so please don't hesitate to reach out via email to share your insights.


### PR DESCRIPTION
- Add code segment ```GetTokenCtx()```
- Add _italics_ to spec. 