### PR TITLE
fix: clarify n3ue configuration parameters to be checked during add process

### DIFF
--- a/docs/guide/n3iwue-installation.md
+++ b/docs/guide/n3iwue-installation.md
@@ -78,12 +78,12 @@ Open your web browser from your host machine, and enter the URL `http://192.168.
 - Once logged in, widen the page until you see “Subscribers” on the left-hand side column.
 - Click on the `Subscribers` tab and then on the `New Subscriber` button
   - Scroll down to `Operator Code Type` and change it from "OPc" to "OP".
-  - Make sure the following config between `n3iwue/config/n3ue.yaml` and `Subscriber` you create are the same:
-    - PLMNID (ex. 208930000001234)
+  - Make sure the following config between `n3iwue/config/n3ue.yaml` and the `Subscriber` you are creating are the same:
+    - SUPI(IMSI) (ex. 208930000001234)
     - K
     - SQN
-    - OP value (choose OP instead of OPC)
-  - Scroll all the way down and click on `Submit`.
+    - OP value (Operator Code Value)
+  - Scroll the page all the way down and click on `Create`.
 
 ## 4. Setting N3IWF Config
 


### PR DESCRIPTION
The docs say "PLMNID" however the example tells to check the SUPI, so I suggest renaming the parameter on the list (perhaps we could add another point for PLMNID as it may not be that obvious to newbies that it must match too?)

A step telling to update OPc to OP already exists a few lines above, so I suggest changing the name of the parameter to the one displayed on the webconsole (Operator Code Value)

The button on the bottom of the page was renamed to Create instead of Submit, so I updated that on this part of the  docs too