### PR TITLE
Update software versions and some other minor improvements

### DIFF
--- a/docs/guide/3-install-free5gc.md
+++ b/docs/guide/3-install-free5gc.md
@@ -131,7 +131,7 @@ sudo ./free5gc/reload_host_config.sh enp0s3
 
         ```
         cd ~
-        git clone --recursive -b v3.4.1 -j `nproc` https://github.com/free5gc/free5gc.git
+        git clone --recursive -b v3.4.2 -j `nproc` https://github.com/free5gc/free5gc.git
         cd free5gc
         ```
 
@@ -172,7 +172,7 @@ sudo ./free5gc/reload_host_config.sh enp0s3
 2. Retrieve the 5G GTP-U kernel module using `git` and build it
 
     ```
-    git clone -b v0.8.6 https://github.com/free5gc/gtp5g.git
+    git clone -b v0.8.10 https://github.com/free5gc/gtp5g.git
     cd gtp5g
     make
     sudo make install

--- a/docs/guide/5-install-ueransim.md
+++ b/docs/guide/5-install-ueransim.md
@@ -22,7 +22,7 @@ Repeat the steps of cloning `free5gc` VM from the base VM, create a new VM for t
 ## 2. Install UERANSIM
 
 Search “ueransim” on the web, and get the [web site](https://github.com/aligungr/UERANSIM).
-On the web site, review what the UERANSIM open-source project is about, then browse into the [installation page](Installation).
+On the web site, check what the UERANSIM open-source project is about. Then navigate to the [installation page](https://github.com/aligungr/UERANSIM/wiki/Installation) or follow the instructions below.
 
 To download UERANSIM:
 ```

--- a/docs/guide/5-install-ueransim.md
+++ b/docs/guide/5-install-ueransim.md
@@ -29,10 +29,13 @@ To download UERANSIM:
 cd ~
 git clone https://github.com/aligungr/UERANSIM
 cd UERANSIM
+# if using free5GC v3.3.0 or below
 git checkout 3a96298
+# if using free5GC v3.4.0 or above
+git checkout e4c492d
 ```
 
-Update and upgrade ueransim VM first:
+Update and upgrade UERANSIM VM first:
 ```
 sudo apt update
 sudo apt upgrade

--- a/docs/guide/Trouble_Shooting.md
+++ b/docs/guide/Trouble_Shooting.md
@@ -66,14 +66,7 @@ If this outputs an error like this:
 modprobe: FATAL: Module gtp5g not found in directory /lib/modules/5.4.0-xxx-generic
 ```
 
-Reinstall the GTP-U kernel module using:
-```bash
-cd ~
-git clone -b v0.8.3 https://github.com/free5gc/gtp5g.git
-cd ~/gtp5g
-sudo make
-sudo make install
-```
+Reinstall the GTP-U kernel module (refer to [these instructions](./3-install-free5gc.md#c-install-user-plane-function-upf))
 
 Then, once running the core `run.sh` script, you should obtain the message on the logs:
 


### PR DESCRIPTION
This PR updates the stable versions of free5GC and GTP5G on the docs (I've used v0.8.10 instead of v0.9.x because of https://github.com/free5gc/go-upf/issues/53)

It removes the GTP module installation instructions from the trouble shooting item no. 7 and adds a URL to the instructions on the install guide so we don't have to update the same information in two different places anymore

And it also adds information regarding the different nightly versions of UERANSIM and their relationship with free5GC releases while updating the URL to UERANSIM wiki that contains its install instructions