### PR TITLE
Revert "chore(deps): bump virtualenv from 20.23.0 to 20.26.6"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ tomlkit==0.11.8
 trove-classifiers==2023.5.24
 urllib3==2.2.2
 userpath==1.8.0
-virtualenv==20.26.6
+virtualenv==20.23.0
 watchdog==3.0.0
 yarg==0.1.9
 zipp==3.19.1


### PR DESCRIPTION
Reverts free5gc/free5gc.github.io#188