### PR TITLE
docs: fix MongoDB GPG key in installation guide

### DIFF
--- a/docs/guide/3-install-free5gc.md
+++ b/docs/guide/3-install-free5gc.md
@@ -66,8 +66,8 @@ lscpu | grep avx
     1. Import the public key used by the package management system
         ```bash
         sudo apt install -y gnupg curl
-        curl -fsSL https://www.mongodb.org/static/pgp/server-7.0.asc | \
-        sudo gpg -o /usr/share/keyrings/mongodb-server-7.0.gpg --dearmor
+        curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc | \
+        sudo gpg -o /usr/share/keyrings/mongodb-server-8.0.gpg --dearmor
         ```
     2. Create a list file for MongoDB
         ```bash


### PR DESCRIPTION
## Summary

The installation guide imports the MongoDB 7.0 key but references the 8.0 keyring when adding the repository.

This causes apt update to fail with:

`NO_PUBKEY 41DE058A4E7DCA05`

This PR updates the documentation to use the correct MongoDB 8.0 GPG key.

## Tested

Tested on Ubuntu 20.04 and Ubuntu 24.04.
The repository can now be added successfully and `apt update` works without errors.